### PR TITLE
Enhancement: 设置各页面标题

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
  * _(:з」∠)_
 -->
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-CN">
 
 <head>
   <meta charset="UTF-8" />

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,7 +5,8 @@
  * @Description: 
  * _(:з」∠)_
  */
-import { createRouter, createWebHashHistory } from 'vue-router';
+import { createRouter, createWebHashHistory } from 'vue-router'
+import { setTitle } from '@/utils/tools'
 
 const router = createRouter({
   history: createWebHashHistory(),
@@ -84,5 +85,23 @@ const router = createRouter({
     },
   ]
 });
+
+router.beforeEach(({ path }) => {
+  // 此处只是尽快响应，设置大类标题。
+  // 之后各组件可以再覆盖。
+
+  const titleMap: Record<string, string> = {
+    '': '欢迎',
+    login: '登录',
+    user: '我',
+    paper: '文章',
+    course: '课程',
+    score: '成绩',
+    about: '关于'
+  }
+  const top = path.split('/').filter(piece => piece.length > 0)[0] ?? ''
+  const title = titleMap[top] ?? top
+  setTitle(title)
+})
 
 export default router;

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -114,6 +114,11 @@ async function Clip(s:string,msg="已复制到剪贴板OvO"){
   }
 }
 
+/** 设置页面标题 */
+export function setTitle(...titles: string[]): void {
+  document.title = `${titles.join(' - ')} | BIT101`
+}
+
 export {
   hitokoto,
   FormatTime,

--- a/src/views/CourseShow.vue
+++ b/src/views/CourseShow.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import http from '@/utils/request';
-import { Clip } from '@/utils/tools';
+import { Clip, setTitle } from '@/utils/tools';
 import { onMounted, reactive } from 'vue';
 import { useRoute } from 'vue-router';
 import { ThumbUpOutlined, ThumbUpFilled, ShareOutlined } from '@vicons/material';
@@ -40,7 +40,7 @@ function Open(url: string) {
 }
 
 function LoadCourse() {
-  http.get('/course/?id=' + course.id).then(res => {
+  return http.get('/course/?id=' + course.id).then(res => {
     let data = res.data;
     course.comment_num = data.comment_num;
     course.like_num = data.like_num;
@@ -57,8 +57,10 @@ function LoadCourse() {
 
 const route = useRoute();
 course.id = route.params.id as string;
-onMounted(() => {
-  LoadCourse();
+onMounted(async () => {
+  await LoadCourse()
+  const teachers_names = course.teachers.map(t => t.name)
+  setTitle(`${course.name}（${teachers_names.join('、')}）`, '课程')
 })
 
 </script>

--- a/src/views/CourseUpload.vue
+++ b/src/views/CourseUpload.vue
@@ -6,11 +6,12 @@
  * _(:з」∠)_
 -->
 <script setup lang="ts">
-import http from '@/utils/request';
-import { reactive, onMounted, ref } from 'vue';
-import { useRoute } from 'vue-router';
+import { reactive, onMounted, ref } from 'vue'
+import { useRoute } from 'vue-router'
 import { UploadCustomRequestOptions, UploadInst } from 'naive-ui'
 import { UploadRound } from '@vicons/material'
+import http from '@/utils/request'
+import { setTitle } from '@/utils/tools'
 
 const course = reactive({
   id: "",
@@ -90,7 +91,7 @@ function Open(url:string){
 }
 
 function LoadCourse() {
-  http.get('/course/?id=' + course.id).then(res => {
+  return http.get('/course/?id=' + course.id).then(res => {
     let data = res.data;
     course.name = data.name;
     course.number = data.number;
@@ -99,8 +100,9 @@ function LoadCourse() {
 
 const route = useRoute();
 course.id = route.params.id as string;
-onMounted(() => {
-  LoadCourse();
+onMounted(async () => {
+  await LoadCourse()
+  setTitle('上传资料', course.name, '课程')
 })
 </script>
 

--- a/src/views/PaperEdit.vue
+++ b/src/views/PaperEdit.vue
@@ -22,6 +22,7 @@ import store from '@/utils/store';
 import { onMounted, reactive, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import PaperRender from '@/components/PaperRender.vue';
+import { setTitle } from '@/utils/tools';
 
 //文章数据
 const paper = reactive({
@@ -139,7 +140,7 @@ function PreviewPaper() {
 function LoadPaper() {
   paper.id = route.params.id as string;
   if (paper.id == '0') InitEditor(false);
-  else http.get("/paper/?id=" + paper.id)
+  else return http.get("/paper/?id=" + paper.id)
     .then(res => {
       paper.title = res.data.title;
       paper.intro = res.data.intro;
@@ -154,8 +155,9 @@ function LoadPaper() {
 
 const route = useRoute();
 const router = useRouter();
-onMounted(() => {
-  LoadPaper();
+onMounted(async () => {
+  await LoadPaper()
+  setTitle('编辑', paper.title, '文章')
 })
 
 //发表文章

--- a/src/views/PaperShow.vue
+++ b/src/views/PaperShow.vue
@@ -11,7 +11,7 @@ import store from '@/utils/store';
 import { onMounted, reactive, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import PaperRender from '@/components/PaperRender.vue';
-import { FormatTime, Clip } from '@/utils/tools';
+import { FormatTime, Clip, setTitle } from '@/utils/tools';
 import { EditOutlined, ThumbUpOutlined, ThumbUpFilled, ShareOutlined } from '@vicons/material';
 import Comment from '@/components/Comment.vue';
 
@@ -38,7 +38,7 @@ const paper = reactive({
 
 //加载文章
 function LoadPaper() {
-  http.get("/paper/?id=" + paper.id)
+  return http.get("/paper/?id=" + paper.id)
     .then(res => {
       paper.title = res.data.title;
       paper.intro = res.data.intro;
@@ -72,8 +72,9 @@ function ClipUrl() {
 const router = useRouter();
 const route = useRoute();
 paper.id = route.params.id as string;
-onMounted(() => {
-  LoadPaper();
+onMounted(async () => {
+  await LoadPaper()
+  setTitle(paper.title, '文章')
 })
 </script>
 


### PR DESCRIPTION
- 设置各页面标题。

  “标题”是指`<title>`，会用于（浏览器）标签页名、历史记录等处。

  1. 为尽快响应，先根据一级页面设置标题，如“课程 | BIT101”。

  2. 二级页面 mounted 最后再补充信息，如“地理北理 - 文章 | BIT101”。

     由于需知道何时加载完成，把若干`Load○○`中的`Promise`返回了出来。

- 顺便更正了一下`<html>`的`lang` 属性。

- 因为原来代码就不统一，有的行有分号，有的行没有，所以我也没有统一。

下面是效果图。

<img width="268" alt="image" src="https://user-images.githubusercontent.com/73375426/183869054-7c51b128-11ae-40c3-bc98-1988aabbe63d.png">

↑以前。

↓现在。

<img width="268" alt="image" src="https://user-images.githubusercontent.com/73375426/183869078-306fb714-a5a4-473c-afac-cfddfbad217e.png">

